### PR TITLE
fix: Use full image path for image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img width="200" height="200" src="binoculars-pngrepo-com.png">
+  <img width="200" height="200" src="https://raw.githubusercontent.com/cerebruminc/detect-high-entropy-strings/master/binoculars-pngrepo-com.png">
   <br>
   <br>
 


### PR DESCRIPTION
This means the image will render correctly when viewing the package on npm.

Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>