### PR TITLE
fix: Add git url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.2",
   "description": "Detect high entropy strings",
   "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:cerebruminc/detect-high-entropy-strings.git"
+  },
   "scripts": {
     "test": "jest",
     "build": "tsc",


### PR DESCRIPTION
This allows sites like npm to link back to the source code for the package.

Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>