### PR TITLE
fix: Correctly ID release step in GitHub action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3
+        id: release
         with:
           release-type: node
           package-name: release-please-action


### PR DESCRIPTION
The release ID means that the conditional npm publish step will work correctly.

Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>